### PR TITLE
Added .gitattributes to preserve LF on windows

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,1 +1,1 @@
-boot-opentelemetry-tempo/boot-otel-tempo-docker/scripts/*.sh eol=lf
+boot-otel-tempo-docker/scripts/*.sh eol=lf

--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,1 @@
+boot-opentelemetry-tempo/boot-otel-tempo-docker/scripts/*.sh eol=lf


### PR DESCRIPTION
Hi,

after trying to run it on Windows I recognized that git is by default changing line endings to CRLF.
By setting .gitattributes they are preserved and docker is buildable otherwise the application was not starting.