### PR TITLE
Fixes issue #33

### DIFF
--- a/boot-otel-tempo-docker/scripts/start-app.sh
+++ b/boot-otel-tempo-docker/scripts/start-app.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+ulimit -n 10000
+
 [ -z "$MIN_HEAP_SIZE" ] && MIN_HEAP_SIZE=40M
 [ -z "$MAX_HEAP_SIZE" ] && MAX_HEAP_SIZE=512M
 [ -z "$THREADSTACK_SIZE" ] && THREADSTACK_SIZE=228k


### PR DESCRIPTION
Adds the command `ulimit -n 10000` to the startup script, so that Java 8 doesn't run out of memory when trying to allocate memory for all possible open files (unlimited in modern Linux'es).